### PR TITLE
Round thumbnail border coordinates, simplify conditions

### DIFF
--- a/modern.lua
+++ b/modern.lua
@@ -143,7 +143,8 @@ local state = {
 local thumbfast = {
     width = 0,
     height = 0,
-    disabled = false
+    disabled = true,
+    available = false
 }
 
 local window_control_box_width = 138
@@ -663,8 +664,8 @@ function render_elements(master_ass)
                     elem_ass:append(tooltiplabel)
 
                     -- thumbnail
-                    if element.thumbnail and not thumbfast.disabled and thumbfast.width ~= 0 and thumbfast.height ~= 0 then
-                        local osd_w = mp.get_property_number("osd-dimensions/w")
+                    if element.thumbnail and not thumbfast.disabled then
+                        local osd_w = mp.get_property_number("osd-width")
                         if osd_w then
                             local r_w, r_h = get_virt_scale_factor()
 
@@ -676,11 +677,14 @@ function render_elements(master_ass)
                             local thumbX = math.min(osd_w - thumbfast.width - thumbMarginX, math.max(thumbMarginX, tx / r_w - thumbfast.width / 2))
                             local thumbY = ((ty - thumbMarginY) / r_h - thumbfast.height)
 
+                            thumbX = math.floor(thumbX + 0.5)
+                            thumbY = math.floor(thumbY + 0.5)
+
                             elem_ass:new_event()
                             elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
                             elem_ass:append(osc_styles.Tooltip)
                             elem_ass:draw_start()
-                            elem_ass:rect_cw(-thumbPad * r_h, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                            elem_ass:rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
                             elem_ass:draw_stop()
 
                             mp.commandv("script-message-to", "thumbfast", "thumb",
@@ -691,7 +695,7 @@ function render_elements(master_ass)
                         end
                     end
                 else
-                    if element.thumbnail and thumbfast.width ~= 0 and thumbfast.height ~= 0 then
+                    if element.thumbnail and thumbfast.available then
                         mp.commandv("script-message-to", "thumbfast", "clear")
                     end
                 end


### PR DESCRIPTION
Thumbnail border could be misaligned by up to half a pixel in both directions.  
That's because image overlays must be aligned to a pixel, but our ASS border wasn't aligned.

Add `math.floor(thumb_pos + 0.5)` to round to the nearest integer and get an even border on all sides.

Fix a horizontal coordinate mistakenly scaled by the vertical scale factor.

Simplify conditions for requesting and clearing thumbnails, requires latest thumbfast.

The thumbnail logic is explicitly disabled, unless the thumbnail script is present.