### PR TITLE
Add option to display milliseconds

### DIFF
--- a/modern.lua
+++ b/modern.lua
@@ -36,6 +36,7 @@ local user_opts = {
                                 -- to be shown as OSC title
     showtitle = true,            -- show title and no hide timeout on pause
     timetotal = true,              -- display total time instead of remaining time?
+    timems = false,             -- display timecodes with milliseconds
     visibility = 'auto',        -- only used at init to set visibility_mode(...)
     windowcontrols = 'auto',    -- whether to show window controls
     volumecontrol = true,       -- whether to show mute button and volumne slider
@@ -115,6 +116,7 @@ local state = {
     active_element = nil,                   -- nil = none, 0 = background, 1+ = see elements[]
     active_event_source = nil,              -- the 'button' that issued the current event
     rightTC_trem = not user_opts.timetotal, -- if the right timecode should display total or remaining time
+    tc_ms = user_opts.timems,               -- should the timecodes display their time with milliseconds
     mp_screen_sizeX, mp_screen_sizeY,       -- last screen-resolution, to detect resolution changes to issue reINITs
     initREQ = false,                        -- is a re-init request pending?
     last_mouseX, last_mouseY,               -- last mouse position, to detect significant mouse movement
@@ -1536,16 +1538,34 @@ function osc_init()
 		end
     -- tc_left (current pos)
     ne = new_element('tc_left', 'button')
-    ne.content = function () return (mp.get_property_osd('playback-time')) end
+    ne.content = function ()
+        if (state.tc_ms) then
+            return (mp.get_property_osd('playback-time/full'))
+        else
+            return (mp.get_property_osd('playback-time'))
+        end
+    end
+    ne.eventresponder['mbtn_left_up'] = function ()
+        state.tc_ms = not state.tc_ms
+        request_init()
+    end
 
     -- tc_right (total/remaining time)
     ne = new_element('tc_right', 'button')
     ne.content = function ()
         if (mp.get_property_number('duration', 0) <= 0) then return '--:--:--' end
         if (state.rightTC_trem) then
-            return ('-'..mp.get_property_osd('playtime-remaining'))
+            if (state.tc_ms) then
+                return ('-'..mp.get_property_osd('playtime-remaining/full'))
+            else
+                return ('-'..mp.get_property_osd('playtime-remaining'))
+            end
         else
-            return (mp.get_property_osd('duration'))
+            if (state.tc_ms) then
+                return (mp.get_property_osd('duration/full'))
+            else
+                return (mp.get_property_osd('duration'))
+            end
         end
     end
     ne.eventresponder['mbtn_left_up'] =


### PR DESCRIPTION
MPV's default OSC allows you to set `timems` so mpv can display times in milliseconds. [reference](https://github.com/mpv-player/mpv/blob/master/DOCS/man/osc.rst)

I often use this feature while editing a video with `ffmpeg`, being able to see the milliseconds helps me a lot. So I added the feature to osc-modern. I used the [default osc.lua](https://github.com/mpv-player/mpv/blob/bca516bd2c282670aa2c92663329e7d5ddf978e0/player/lua/osc.lua) as a reference to add this feature.

I use the branch `with.thumbfast` myself, so after merging this into `main`, could you merge it into `with.thumbfast` too? If you prefer, I can also create a new PR.

Thank you for creating this plugin, my mpv now looks good!!