### PR TITLE
fix: osc option `hidetimeout` not work

### DIFF
--- a/modern.lua
+++ b/modern.lua
@@ -1669,8 +1669,18 @@ function request_tick()
     end
 end
 
+-- check if cursor is in player
+function cursor_in_player()
+    local x = state.last_mouseX
+    local y = state.last_mouseY
+    local gap = 32
+    local x_in = x ~= nil and x > gap and x < (osc_param.playresx - gap)
+    local y_in = y ~= nil and y > gap and y < (osc_param.playresy - gap)
+    return x_in and y_in
+end
+
 function mouse_leave()
-    if get_hidetimeout() >= 0 then
+    if get_hidetimeout() >= 0 and cursor_in_player() == false then
         hide_osc()
     end
     -- reset mouse position


### PR DESCRIPTION
when cursor leaves osc area, osc will hide immediately ignoring `hidetimeout` value.

after this commit:
if cursor leaves osc area but still in the player, `render()` will auto hide osc after `hidetimeout`.
if cursor is out of the player, osc will hide immediately.
